### PR TITLE
fix build error caused by missing type declaration in npm module

### DIFF
--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'jsonexport/dist';


### PR DESCRIPTION
Not all NPM modules include a typescript declaration file which causes a build error. We can fix this by simply declaring it in our own project, so I created an index.d.ts where I added the module declaration.